### PR TITLE
Add initial Meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,17 @@
+project('ffui',
+  'cpp',
+  default_options: ['warning_level=3', 'cpp_std=c++17'],
+  license: 'MIT',
+  meson_version: '>=1.3.0',
+  version: '1.0',
+)
+
+curses_dep = dependency('curses')
+rapidfuzz_dep = dependency('rapidfuzz')
+deps = [curses_dep, rapidfuzz_dep]
+
+app_sources = ['src/main.cpp', 'src/ffui.cpp']
+executable('ffui_app', app_sources, dependencies: deps)
+
+lib_sources = ['src/ffui.cpp']
+library('ffui', lib_sources, dependencies: deps)

--- a/subprojects/rapidfuzz-cpp.wrap
+++ b/subprojects/rapidfuzz-cpp.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/rapidfuzz/rapidfuzz-cpp.git
+revision = v3.0.4
+depth = 1
+method = cmake
+
+[provide]
+rapidfuzz = rapidfuzz_dep


### PR DESCRIPTION
Add initial support for the [Meson Build System](https://mesonbuild.com/).

Build and run the app:

```sh
meson setup builddir && meson compile -C builddir && ./builddir/ffui_app
```
Unlike CMake, the C++ standard is C++17. This is because compilation of [rapidfuzz-cpp](https://github.com/rapidfuzz/rapidfuzz-cpp) fails in C++11.